### PR TITLE
Fixed Api Error

### DIFF
--- a/example/src/pages/api/login.ts
+++ b/example/src/pages/api/login.ts
@@ -15,7 +15,7 @@ const handler: NextApiHandler = (req, res) => {
     const redirectParams = new URLSearchParams({
       response_type: "code",
       client_id: SPOTIFY_CLIENT_ID,
-      scope: encodeURIComponent(SPOTIFY_SCOPES.join(" ")),
+      scope: SPOTIFY_SCOPES.join(" "),
       redirect_uri: SPOTIFY_REDIRECT_URI,
       state: state,
     });


### PR DESCRIPTION
Editing line 18 of login.ts in the api folder, and removing the  "encodeURIComponent" function seemed to fix an 400 error that I got when I tried to login. I found this same error when I tried to login to your example hosted on vercel.